### PR TITLE
Improve trade menu performance

### DIFF
--- a/1.4/Source/VanillaPsycastsExpanded/HarmonyPatches/Transferable_CanAdjustBy_Patch.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/HarmonyPatches/Transferable_CanAdjustBy_Patch.cs
@@ -2,9 +2,7 @@
 {
     using HarmonyLib;
     using RimWorld;
-    using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
     using UnityEngine;
     using Verse;
 
@@ -12,15 +10,6 @@
 	public static class Transferable_CanAdjustBy_Patch
     {
         public static Transferable curTransferable;
-        private static readonly HashSet<ThingDef> eltexThings;
-
-        static Transferable_CanAdjustBy_Patch()
-        {
-            eltexThings = DefDatabase<RecipeDef>.AllDefs
-                .Where(recipe => recipe.ingredients.Any(x => x.IsFixedIngredient && x.FixedIngredient == VPE_DefOf.VPE_Eltex))
-                .Select(recipe => recipe.ProducedThingDef)
-                .ToHashSet();
-        }
 
 		public static void Postfix(Transferable __instance)
 		{
@@ -38,25 +27,5 @@
                 }
             }
 		}
-
-        public static bool IsEltexOrHasEltexMaterial(this ThingDef def)
-        {
-            if (def != null)
-            {
-                if (def == VPE_DefOf.VPE_Eltex)
-                {
-                    return true;
-                }
-                else if (def.costList != null && def.costList.Any(x => x.thingDef == VPE_DefOf.VPE_Eltex))
-                {
-                    return true;
-                }
-                else if (eltexThings.Contains(def))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
     }
 }

--- a/1.4/Source/VanillaPsycastsExpanded/HarmonyPatches/Transferable_CanAdjustBy_Patch.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/HarmonyPatches/Transferable_CanAdjustBy_Patch.cs
@@ -12,8 +12,8 @@
         public static Transferable curTransferable;
 		public static void Postfix(Transferable __instance)
 		{
-            if (curTransferable != __instance && Find.WindowStack.IsOpen<Dialog_Trade>() && TradeSession.trader != null 
-                && __instance.ThingDef.IsEltexOrHasEltexMaterial() &&  TradeSession.trader.Faction != Faction.OfEmpire && __instance.CountToTransferToDestination > 0)
+            if (curTransferable != __instance && Find.WindowStack.IsOpen<Dialog_Trade>() && __instance.CountToTransferToDestination > 0 && TradeSession.trader != null
+                && TradeSession.trader.Faction != Faction.OfEmpire && __instance.ThingDef.IsEltexOrHasEltexMaterial())
             {
                 curTransferable = __instance;
                 if (TradeSession.giftMode)

--- a/1.4/Source/VanillaPsycastsExpanded/HarmonyPatches/Transferable_CanAdjustBy_Patch.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/HarmonyPatches/Transferable_CanAdjustBy_Patch.cs
@@ -2,7 +2,9 @@
 {
     using HarmonyLib;
     using RimWorld;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using UnityEngine;
     using Verse;
 
@@ -10,6 +12,16 @@
 	public static class Transferable_CanAdjustBy_Patch
     {
         public static Transferable curTransferable;
+        private static readonly HashSet<ThingDef> eltexThings;
+
+        static Transferable_CanAdjustBy_Patch()
+        {
+            eltexThings = DefDatabase<RecipeDef>.AllDefs
+                .Where(recipe => recipe.ingredients.Any(x => x.IsFixedIngredient && x.FixedIngredient == VPE_DefOf.VPE_Eltex))
+                .Select(recipe => recipe.ProducedThingDef)
+                .ToHashSet();
+        }
+
 		public static void Postfix(Transferable __instance)
 		{
             if (curTransferable != __instance && Find.WindowStack.IsOpen<Dialog_Trade>() && __instance.CountToTransferToDestination > 0 && TradeSession.trader != null
@@ -39,15 +51,9 @@
                 {
                     return true;
                 }
-                else
+                else if (eltexThings.Contains(def))
                 {
-                    foreach (var recipe in DefDatabase<RecipeDef>.AllDefs)
-                    {
-                        if (recipe.ProducedThingDef == def && recipe.ingredients.Any(x => x.IsFixedIngredient && x.FixedIngredient == VPE_DefOf.VPE_Eltex))
-                        {
-                            return true;
-                        }
-                    }
+                    return true;
                 }
             }
             return false;

--- a/1.4/Source/VanillaPsycastsExpanded/PsycastUtility.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/PsycastUtility.cs
@@ -1,10 +1,42 @@
 ﻿namespace VanillaPsycastsExpanded;
 
 using RimWorld;
+using System.Collections.Generic;
+using System.Linq;
 using Verse;
 
 public static class PsycastUtility
 {
+    public static readonly HashSet<ThingDef> eltexThings;
+
+    static PsycastUtility()
+    {
+        eltexThings = DefDatabase<RecipeDef>.AllDefs
+            .Where(recipe => recipe.ingredients.Any(x => x.IsFixedIngredient && x.FixedIngredient == VPE_DefOf.VPE_Eltex))
+            .Select(recipe => recipe.ProducedThingDef)
+            .ToHashSet();
+    }
+
+    public static bool IsEltexOrHasEltexMaterial(this ThingDef def)
+    {
+        if (def != null)
+        {
+            if (def == VPE_DefOf.VPE_Eltex)
+            {
+                return true;
+            }
+            else if (def.costList != null && def.costList.Any(x => x.thingDef == VPE_DefOf.VPE_Eltex))
+            {
+                return true;
+            }
+            else if (eltexThings.Contains(def))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static Hediff_PsycastAbilities Psycasts(this Pawn pawn) =>
         (Hediff_PsycastAbilities)pawn.health.hediffSet.GetFirstHediffOfDef(VPE_DefOf.VPE_PsycastAbilityImplant);
 

--- a/1.4/Source/VanillaPsycastsExpanded/PsycastUtility.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/PsycastUtility.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Verse;
 
+[StaticConstructorOnStartup]
 public static class PsycastUtility
 {
     public static readonly HashSet<ThingDef> eltexThings;

--- a/1.4/Source/VanillaPsycastsExpanded/PsycastUtility.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/PsycastUtility.cs
@@ -19,22 +19,10 @@ public static class PsycastUtility
 
     public static bool IsEltexOrHasEltexMaterial(this ThingDef def)
     {
-        if (def != null)
-        {
-            if (def == VPE_DefOf.VPE_Eltex)
-            {
-                return true;
-            }
-            else if (def.costList != null && def.costList.Any(x => x.thingDef == VPE_DefOf.VPE_Eltex))
-            {
-                return true;
-            }
-            else if (eltexThings.Contains(def))
-            {
-                return true;
-            }
-        }
-        return false;
+        return def != null &&
+            (def == VPE_DefOf.VPE_Eltex ||
+            (def.costList != null && def.costList.Any(x => x.thingDef == VPE_DefOf.VPE_Eltex)) ||
+            eltexThings.Contains(def));
     }
 
     public static Hediff_PsycastAbilities Psycasts(this Pawn pawn) =>

--- a/1.4/Source/VanillaPsycastsExpanded/PsycastUtility.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/PsycastUtility.cs
@@ -8,7 +8,7 @@ using Verse;
 [StaticConstructorOnStartup]
 public static class PsycastUtility
 {
-    public static readonly HashSet<ThingDef> eltexThings;
+    private static readonly HashSet<ThingDef> eltexThings;
 
     static PsycastUtility()
     {


### PR DESCRIPTION
`IsEltexOrHasEltexMaterial` is currently tanking my frame rate from 60 -> 20 fps whenever I open the trade menu. I have a large load order, so I assume it's because I have a lot of craftables. This patch changes the order in which conditions are checked so we're evaluating conditions from least to most computationally expensive.