### PR TITLE
Fix a psyfocus exploit

### DIFF
--- a/1.4/Source/VanillaPsycastsExpanded/AbilityExtension_Psycast.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/AbilityExtension_Psycast.cs
@@ -163,6 +163,19 @@ public class AbilityExtension_Psycast : AbilityExtension_AbilityMod
             }
     }
 
+    public override bool Valid(GlobalTargetInfo[] targets, Ability ability, bool throwMessages = false)
+    {
+        var valid = base.Valid(targets, ability, throwMessages);
+        if (valid)
+        {
+            string reason;
+            valid = IsEnabledForPawn(ability, out reason);
+            if (!valid && throwMessages) Messages.Message(reason, MessageTypeDefOf.RejectInput, false);
+        }
+
+        return valid;
+    }
+
     public override bool ValidateTarget(LocalTargetInfo target, Ability ability, bool throwMessages = false)
     {
         if (psychic && target.Pawn is { } p && p.GetStatValue(StatDefOf.PsychicSensitivity) < 1.401298E-45f)


### PR DESCRIPTION
Users could cast a psyability even if they did not have the required psyfocus as long as they had the action queued before they ran out of psyfocus.

How to replicate:
* Add a psyability to a pawn (i.e. _Enchant quality_)
* Pause the game
* Cast the psyability
* Select the pysability again, but do not cast it
* Unpause the game
* After the psyability is cast, you may now freely cast it again, regardless of psyfocus cost