### PR TITLE
Fix a translation error when reporting pawns incapable of walking

### DIFF
--- a/1.4/Source/VanillaPsycastsExpanded/AbilityExtension_Psycast.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/AbilityExtension_Psycast.cs
@@ -85,7 +85,7 @@ public class AbilityExtension_Psycast : AbilityExtension_AbilityMod
 
             if (ability.pawn.Downed)
             {
-                reason = "IsIncapped".Translate(ability.pawn);
+                reason = "IsIncapped".Translate(ability.pawn.LabelShort, ability.pawn);
                 return false;
             }
 


### PR DESCRIPTION
Otherwise it throws a red error in the log when you select a psycasting, incapacitated pawn. For reference, the full string is:
```
<IsIncapped>{1_labelShort} cannot walk.</IsIncapped>
```