### PR TITLE
Replace `Find.CurrentMap` with `Pawn.Map`

### DIFF
--- a/1.4/Source/VanillaPsycastsExpanded/Paths/Harmonist/HediffComp_MindControl.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/Paths/Harmonist/HediffComp_MindControl.cs
@@ -34,7 +34,7 @@ public class HediffComp_MindControl : HediffComp_Ability
             if (oldLord == null)
             {
                 LordJob_DefendPoint lordJob = new(Pawn.Position);
-                oldLord = LordMaker.MakeNewLord(oldFaction, lordJob, Find.CurrentMap);
+                oldLord = LordMaker.MakeNewLord(oldFaction, lordJob, Pawn.Map);
             }
         }
 


### PR DESCRIPTION
The pawn's map is used a few lines earlier, so it's guaranteed to not be null at that point.