### PR TITLE
Word Of Animal and Group Link fixes.

### DIFF
--- a/1.3/Source/VanillaPsycastsExpanded/Paths/Archon/Hediff_GroupLink.cs
+++ b/1.3/Source/VanillaPsycastsExpanded/Paths/Archon/Hediff_GroupLink.cs
@@ -33,7 +33,7 @@
         public void LinkAllPawnsAround()
         {
             foreach (var pawnToLink in GenRadial.RadialDistinctThingsAround(pawn.Position, pawn.Map, this.ability.GetRadiusForPawn(), true)
-                .OfType<Pawn>().Where(x => x.RaceProps.Humanlike && x != pawn))
+                .OfType<Pawn>().Where(x => x != pawn))
             {
                 if (!linkedPawns.Contains(pawnToLink))
                 {

--- a/1.3/Source/VanillaPsycastsExpanded/Paths/Wildspeaker/Ability_Animal.cs
+++ b/1.3/Source/VanillaPsycastsExpanded/Paths/Wildspeaker/Ability_Animal.cs
@@ -5,7 +5,7 @@ using RimWorld.Planet;
 using Verse;
 using Ability = VFECore.Abilities.Ability;
 
-public class Ability_Animal : Ability
+public class Ability_Animal : Ability_WordOf
 {
     public override void Cast(params GlobalTargetInfo[] targets)
     {

--- a/1.4/Source/VanillaPsycastsExpanded/Paths/Archon/Hediff_GroupLink.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/Paths/Archon/Hediff_GroupLink.cs
@@ -33,7 +33,7 @@
         public void LinkAllPawnsAround()
         {
             foreach (var pawnToLink in GenRadial.RadialDistinctThingsAround(pawn.Position, pawn.Map, this.ability.GetRadiusForPawn(), true)
-                .OfType<Pawn>().Where(x => x.RaceProps.Humanlike && x != pawn))
+                .OfType<Pawn>().Where(x => x != pawn))
             {
                 if (!linkedPawns.Contains(pawnToLink))
                 {

--- a/1.4/Source/VanillaPsycastsExpanded/Paths/Wildspeaker/Ability_Animal.cs
+++ b/1.4/Source/VanillaPsycastsExpanded/Paths/Wildspeaker/Ability_Animal.cs
@@ -5,7 +5,7 @@ using RimWorld.Planet;
 using Verse;
 using Ability = VFECore.Abilities.Ability;
 
-public class Ability_Animal : Ability
+public class Ability_Animal : Ability_WordOf
 {
     public override void Cast(params GlobalTargetInfo[] targets)
     {


### PR DESCRIPTION
Word of animals using wrong base class and Group Link can't affect it that way.
Group Link is limited to humanlike pawns and animals can't be affected by it.