### PR TITLE
added <isBad>false</isBad> to correct a bunch of hediffs

### DIFF
--- a/1.4/Defs/AbilityDefs/Harmonist.xml
+++ b/1.4/Defs/AbilityDefs/Harmonist.xml
@@ -52,6 +52,7 @@
     <castSound>VPE_PsychicGuidance_Cast</castSound>
     <showUndrafted>true</showUndrafted>
     <chance>0</chance>
+	<isBad>false</isBad>
     <modExtensions>
       <li Class="VanillaPsycastsExpanded.AbilityExtension_Psycast">
         <path>VPE_Harmonist</path>

--- a/1.4/Defs/HediffDefs/Hediffs.xml
+++ b/1.4/Defs/HediffDefs/Hediffs.xml
@@ -6,6 +6,7 @@
 		<description>Electricity is being channeled to a nearby battery.</description>
 		<initialSeverity>1</initialSeverity>
 		<hediffClass>HediffWithComps</hediffClass>
+		<isBad>false</isBad>
 		<comps>
 			<li Class="VFECore.Shields.HediffCompProperties_Draw">
 				<compClass>VanillaPsycastsExpanded.Staticlord.HediffComp_Recharge</compClass>
@@ -18,6 +19,7 @@
 			</li>
 		</comps>
 	</HediffDef>
+	
 	<HediffDef>
 		<defName>VPE_Vortex</defName>
 		<label>vortex</label>
@@ -25,6 +27,7 @@
 		<initialSeverity>1</initialSeverity>
 		<hediffClass>VanillaPsycastsExpanded.Staticlord.Hediff_Vortexed</hediffClass>
 	</HediffDef>
+	
 	<HediffDef>
 		<defName>VPE_Hurricane</defName>
 		<label>hurricane</label>
@@ -240,6 +243,7 @@
 		<label>ice shield</label>
 		<description>A psychic shield that protects from hypothermia and freezer enemies that interact with it.</description>
 		<hediffClass>VanillaPsycastsExpanded.Hediff_IceShield</hediffClass>
+		<isBad>false</isBad>
 		<comps>
 			<li Class="VanillaPsycastsExpanded.HediffCompProperties_PlaySound">
 				<endSound>VPE_IceShield_End</endSound>
@@ -355,16 +359,19 @@
 			</li>
 		</comps>
 	</HediffDef>
+	
 	<HediffDef ParentName="PsycastHediffBase">
 		<defName>VPE_AnimalOvershield</defName>
 		<label>animal shield</label>
 		<description>An overshield that protects the animal from any ranged attacks.</description>
 		<hediffClass>VanillaPsycastsExpanded.Wildspeaker.Hediff_AnimalShield</hediffClass>
 	</HediffDef>
+	
 	<HediffDef ParentName="PsycastHediffBase">
 		<defName>VPE_Smartbuzz</defName>
 		<label>smartbuzz</label>
 		<description>Psychically-induced feelings of clarity and curiosity. This improves research speed as well as skill gain speed.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statFactors>
@@ -384,11 +391,13 @@
 			<li Class="HediffCompProperties_DisappearsOnDeath" />
 		</comps>
 	</HediffDef>
+	
 	<HediffDef ParentName="PsycastHediffBase">
 		<defName>VPE_Darkvision</defName>
 		<label>darkvision</label>
 		<description>Psychically-induced ability to see through the darkness and shadows.</description>
 		<hediffClass>VanillaPsycastsExpanded.Nightstalker.Hediff_Darkvision</hediffClass>
+		<isBad>false</isBad>
 		<woundAnchorRange>0</woundAnchorRange>
 		<displayWound>true</displayWound>
 		<stages>
@@ -410,6 +419,7 @@
 			</li>
 		</stages>
 	</HediffDef>
+	
 	<HediffDef>
 		<defName>VPE_Darkvision_Display</defName>
 		<label>darkvision</label>
@@ -423,6 +433,7 @@
 		<defName>VPE_Productivity</defName>
 		<label>psychic productivity</label>
 		<description>Psychically-induced improvement to work speed.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<hungerRateFactor>1.25</hungerRateFactor>
@@ -437,6 +448,7 @@
 		<defName>VPE_PsychicSoothe</defName>
 		<label>psychic soothe</label>
 		<description>Psychically-induced, self-satisfying perceptual distortions, giving a temporary mood boost.</description>
+		<isBad>false</isBad>
 	</HediffDef>
 
 	<HediffDef>
@@ -462,6 +474,7 @@
 		<defName>VPE_Protection</defName>
 		<label>psychic protection</label>
 		<description>Psychically-induced physical protection from incoming damage.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statFactors>
@@ -533,6 +546,7 @@
 		<defName>VPE_GainedVitality</defName>
 		<label>psychic vitality</label>
 		<description>Psychically-induced vitality stolen from another person.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<restFallFactor>0.5</restFallFactor>
@@ -577,6 +591,7 @@
 		<defName>VPE_Ghostwalk</defName>
 		<label>ghostwalk</label>
 		<description>Psychically-induced matter phasing.</description>
+		<isBad>false</isBad>
 		<comps>
 			<li Class="HediffCompProperties">
 				<compClass>VFECore.HediffComp_Phasing</compClass>
@@ -613,6 +628,7 @@
 		<label>death shield</label>
 		<description>Psychically-induced immortality that lasts for one day.</description>
 		<hediffClass>VanillaPsycastsExpanded.Hediff_Deathshield</hediffClass>
+		<isBad>false</isBad>
 		<comps>
 			<li Class="HediffCompProperties_Effecter">
 				<stateEffecter>VPE_BlackSmoke</stateEffecter>
@@ -645,6 +661,7 @@
 		<label>shadowfocus</label>
 		<description>Psychically-induced increase to psychic sensitivity based on the lack of light around the psycaster.</description>
 		<hediffClass>VanillaPsycastsExpanded.Nightstalker.Hediff_ShadowFocus</hediffClass>
+		<isBad>false</isBad>
 		<comps>
 			<li Class="HediffCompProperties_Effecter">
 				<stateEffecter>VPE_BlackSmoke</stateEffecter>

--- a/1.4/Defs/HediffDefs/Hediffs_Global_Misc.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Global_Misc.xml
@@ -4,12 +4,11 @@
 	<HediffDef>
 		<defName>VPE_NoPain</defName>
 		<description>This creature has a reduced pain sensitivity, and it takes longer to be downed due to pain.</description>
-
 		<label>no pain sensitivity</label>
 		<defaultLabelColor>(.8,0,0)</defaultLabelColor>
 		<scenarioCanAdd>false</scenarioCanAdd>
 		<maxSeverity>1.0</maxSeverity>
-
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<painFactor>0</painFactor>

--- a/1.4/Defs/HediffDefs/Protector.xml
+++ b/1.4/Defs/HediffDefs/Protector.xml
@@ -4,6 +4,7 @@
 		<defName>VPE_Healing</defName>
 		<label>psychic healing</label>
 		<description>Psychically-induced healing boost.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<naturalHealingFactor>3</naturalHealingFactor>
@@ -15,6 +16,7 @@
 		<defName>VPE_BlockBleeding</defName>
 		<label>psychic stabilization</label>
 		<description>Psychically-induced stasis that stops any bleeding.</description>
+		<isBad>false</isBad>
 		<comps>
 			<li Class="HediffCompProperties_Effecter">
 				<stateEffecter>VPE_SparksYellow</stateEffecter>
@@ -26,6 +28,7 @@
 		<defName>VPE_Immunity</defName>
 		<label>psychic immunity</label>
 		<description>Psychically-induced immunity boost.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statOffsets>
@@ -40,6 +43,7 @@
 		<label>psychic overshield</label>
 		<description>Psychically-induced personal skipbarrier. Impenetrable by ranged projectiles.</description>
 		<hediffClass>VanillaPsycastsExpanded.Hediff_Overshield</hediffClass>
+		<isBad>false</isBad>
 		<comps>
 			<li Class="VanillaPsycastsExpanded.HediffCompProperties_DisappearsOnDowned"/>
 			<li Class="VanillaPsycastsExpanded.HediffCompProperties_DisappearsOnDespawn"/>
@@ -51,6 +55,7 @@
 		<label>guardian skipbarrier</label>
 		<description>Psychically crafted defensive barrier that generates large amounts of psychic heat in order to sustain itself.</description>
 		<hediffClass>VanillaPsycastsExpanded.Hediff_GuardianSkipBarrier</hediffClass>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statOffsets>
@@ -87,6 +92,7 @@
 		<defName>VPE_Regenerating</defName>
 		<label>regenerating</label>
 		<description>Regenerating wounds, new and old.</description>
+		<isBad>false</isBad>
 		<tendable>false</tendable>
 		<injuryProps>
 			<painPerSeverity>0</painPerSeverity>

--- a/1.4/Defs/HediffDefs/PsycastHediff.xml
+++ b/1.4/Defs/HediffDefs/PsycastHediff.xml
@@ -5,6 +5,7 @@
     <label>psylink</label>
     <description>Go away cheater</description>
     <hediffClass>VanillaPsycastsExpanded.Hediff_PsycastAbilities</hediffClass>
+	<isBad>false</isBad>
     <initialSeverity>1</initialSeverity> 
     <minSeverity>0</minSeverity>
     <keepOnBodyPartRestoration>True</keepOnBodyPartRestoration>

--- a/1.4/Defs/HediffDefs/Shields.xml
+++ b/1.4/Defs/HediffDefs/Shields.xml
@@ -6,6 +6,7 @@
         <description>A shield of fire, sets melee attackers on fire</description>
         <initialSeverity>1</initialSeverity>
         <hediffClass>HediffWithComps</hediffClass>
+		<isBad>false</isBad>
         <comps>
             <li Class="VFECore.Shields.HediffCompProperties_Shield">
                 <compClass>VanillaPsycastsExpanded.Conflagrator.HediffComp_FireShield</compClass>

--- a/1.4/Defs/HediffDefs/Warlord.xml
+++ b/1.4/Defs/HediffDefs/Warlord.xml
@@ -4,6 +4,7 @@
 		<defName>VPE_SpeedBoost</defName>
 		<label>psychic agility</label>
 		<description>Psychically induced agility boost, greatly increasing movement speed.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statFactors>
@@ -22,6 +23,7 @@
 		<defName>VPE_BladeFocus</defName>
 		<label>blade focus</label>
 		<description>Psychically induced combat focus, greatly enhancing melee combat capabilities.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statFactors>
@@ -40,6 +42,7 @@
 		<defName>VPE_FiringFocus</defName>
 		<label>firing focus</label>
 		<description>Psychically induced combat focus, greatly enhancing ranged combat capabilities.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statFactors>
@@ -58,6 +61,7 @@
 		<defName>VPE_AdrenalineRush</defName>
 		<label>psychic rush</label>
 		<description>Psychically induced adrenaline rush, increasing sight, hearing and movement capabilities.</description>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<painFactor>0</painFactor>
@@ -84,6 +88,7 @@
 		<label>psychic frenzy</label>
 		<description>Temporary, psychically induced frenzy. The energy restores itself with each consecutive kill.</description>
 		<hediffClass>VFECore.Abilities.Hediff_Ability</hediffClass>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statFactors>
@@ -107,6 +112,7 @@
 		<label>guided shot</label>
 		<description>Psychically induced insane accuracy.</description>
 		<hediffClass>VFECore.Abilities.Hediff_Ability</hediffClass>
+		<isBad>false</isBad>
 		<stages>
 			<li>
 				<statFactors>


### PR DESCRIPTION
Added <isBad>false</isBad> to correct a bunch of hediffs so they properly register as beneficial. This can help greatly with effects which remove bad hediffs, particularly healing effects like a healer mech serum or MakaitechPsycasts Reverse Fate effect.