### PR TITLE
Don't break on null heat givers

### DIFF
--- a/1.5/Source/VanillaPsycastsExpanded/Hediff_PsycastAbilities.cs
+++ b/1.5/Source/VanillaPsycastsExpanded/Hediff_PsycastAbilities.cs
@@ -99,7 +99,7 @@ public class Hediff_PsycastAbilities : Hediff_Abilities
                 new() { stat = StatDefOf.PsychicEntropyRecoveryRate, value = level * 0.0125f + statPoints * 0.05f },
                 new() { stat = StatDefOf.PsychicSensitivity, value = statPoints * 0.05f },
                 new() { stat = VPE_DefOf.VPE_PsyfocusCostFactor, value = statPoints * -0.01f },
-                new() { stat = VPE_DefOf.VPE_PsychicEntropyMinimum, value = minHeatGivers.Sum(giver => giver.MinHeat) }
+                new() { stat = VPE_DefOf.VPE_PsychicEntropyMinimum, value = minHeatGivers.Sum(giver => giver.MinHeat ?? 0) }
             },
             becomeVisible = false
         };


### PR DESCRIPTION
Hello, let me first say I love the mod and really appreciate all your hard work!

I've recently had an issue where it appeared that my psycaster lost his psychic abilities (looks like this is the same issue as [this](https://steamcommunity.com/workshop/filedetails/discussion/2842502659/4034728517976782413/))
After some debugging, I realized this was because the pawn had a null value in his `minHeatGivers` list.

I'm almost sure this is because of some mod conflict, namely with either the way maps are removed in SOS2 or in the couple of SkipDoor mods I recklessly added mid save - "Skipdoor Delivery" and "Better VPE Skipdoor Pathing".
Unfortunately I couldn't recreate the issue, even when removing SOS2 maps with skipdoors on them, and when I looked at the related code I didn't see any problems.

Regardless of the source, I think VPE should handle such cases. 
The proposed change is very basic. Removing the null value is better, but I'm not sure where that code is supposed to go.
To be honest, I'm not even sure the code I suggested works - I haven't recompiled the mod to check.

Would appreciate your input, thanks!