### PR TITLE
Changes to psychic coma

### DIFF
--- a/1.5/Defs/AbilityDefs/Archon.xml
+++ b/1.5/Defs/AbilityDefs/Archon.xml
@@ -274,8 +274,11 @@
 	<VFECore.Abilities.AbilityDef ParentName="VPE_PsycastBase">
 		<defName>VPE_MassHallucination</defName>
 		<label>mass hallucination</label>
-		<description>Creating a massive burst of psychic suggestion, convinced nearby pawns that rooms are the absolute best they could possibly be. The resulting coma for the caster and the effect lasts for five days.</description>
+		<description>Creating a massive burst of psychic suggestion, convinced nearby pawns that rooms are the absolute best they could possibly be. The caster is put into a coma and the resulting effect lasts for five days.</description>
 		<iconPath>Abilities/Archon/MassHallucination</iconPath>
+		<!-- Replace with VFECore.Abilities.Ability_Blank for 1.6 update. -->
+		<!-- We cannot do this right now as modifying abilityClass doesn't update existing abilities in-game. -->
+		<!-- Once that happens, also consider adding warnings for using Ability_PsychicComa (or remove it entirely). -->
 		<abilityClass>VanillaPsycastsExpanded.Ability_PsychicComa</abilityClass>
 		<castSound>VPE_MassHallucination_Cast</castSound>
 		<targetMode>Self</targetMode>
@@ -303,6 +306,9 @@
 			</li>
 			<li Class="VFECore.Abilities.AbilityExtension_Hediff">
 				<hediff>VPE_Hallucination</hediff>
+			</li>
+			<li Class="VanillaPsycastsExpanded.AbilityExtension_PsychicComa">
+				<hours>120</hours>
 			</li>
 		</modExtensions>
 	</VFECore.Abilities.AbilityDef>

--- a/1.5/Defs/AbilityDefs/Archotechist.xml
+++ b/1.5/Defs/AbilityDefs/Archotechist.xml
@@ -292,7 +292,7 @@
   <VFECore.Abilities.AbilityDef ParentName="VPE_PsycastBase">
     <defName>VPE_Neuroquake</defName>
     <label>neuroquake</label>
-    <description>Find a discontinuity in the psychic field and unfold it, releasing a massive amount of psychic energy. Every creature in range but outside of the safe inner circle will be driven violently insane. Casting this takes 12 seconds of meditation, and afterwards, the caster will go into a five-day psychic coma. The disturbing neuroquake echoes will inflict pain on everyone for many kilometers around, causing diplomatic consequences with all factions.</description>
+    <description>Find a discontinuity in the psychic field and unfold it, releasing a massive amount of psychic energy. Every creature in range but outside of the safe inner circle will be driven violently insane. Casting this takes 12 seconds of meditation, and afterwards, the caster will go into a psychic coma. The disturbing neuroquake echoes will inflict pain on everyone for many kilometers around, causing diplomatic consequences with all factions.</description>
     <iconPath>Abilities/Archotechist/Neuroquake</iconPath>
     <abilityClass>VFECore.Abilities.Ability_Blank</abilityClass>
     <jobDef>VFEA_UseAbilityUninterruptible</jobDef>
@@ -307,7 +307,7 @@
     <radius>60</radius>
     <modExtensions>
       <li Class="VFECore.Abilities.AbilityExtension_ConfirmationMessage">
-        <message>If you use neuroquake, everyone in this region will feel the neuroquake echo, you will lose goodwill with every non-hostile faction.\n\nNeuroquake takes 12 seconds to cast, and cannot be interrupted. When complete, the caster will fall into a psychic coma for 5 days.\n\nEveryone in range except those in a small circle around the caster will be affected.\n\nDo you really want to cast neuroquake?</message>
+        <message>If you use neuroquake, everyone in this region will feel the neuroquake echo, you will lose goodwill with every non-hostile faction.\n\nNeuroquake takes 12 seconds to cast, and cannot be interrupted. When complete, the caster will fall into a psychic coma for up to 5 days.\n\nEveryone in range except those in a small circle around the caster will be affected.\n\nDo you really want to cast neuroquake?</message>
       </li>
       <li Class="VanillaPsycastsExpanded.AbilityExtension_Psycast">
         <path>VPE_Archotechist</path>
@@ -333,6 +333,9 @@
       <li Class="VFECore.Abilities.AbilityExtension_FleckOnTarget">
         <fleckDef>PsychicApplyNeuroquake</fleckDef>
         <sound>Psycast_Neuroquake_Effect</sound>
+      </li>
+      <li Class="VanillaPsycastsExpanded.AbilityExtension_PsychicComa">
+        <hours>120</hours>
       </li>
     </modExtensions>
   </VFECore.Abilities.AbilityDef>

--- a/1.5/Defs/AbilityDefs/Chronopath.xml
+++ b/1.5/Defs/AbilityDefs/Chronopath.xml
@@ -35,7 +35,7 @@
   <VFECore.Abilities.AbilityDef ParentName="VPE_PsycastBase">
     <defName>VPE_TimeskipMeditation</defName>
     <label>timeskip meditation</label>
-    <description>Puts the caster into a self-inflicted coma for a full day as they earn a considerable amount of experience toward their next Psycast level and regain full Psyfocus. Biologically ages the caster by five years.</description>
+    <description>Puts the caster into a self-inflicted coma as they earn a considerable amount of experience toward their next Psycast level and regain full Psyfocus. Biologically ages the caster by five years.</description>
     <iconPath>Abilities/Chronopath/TimeskipMeditation</iconPath>
     <abilityClass>VanillaPsycastsExpanded.Chronopath.Ability_Meditate</abilityClass>
     <targetMode>Self</targetMode>
@@ -297,7 +297,7 @@
   <VFECore.Abilities.AbilityDef ParentName="VPE_PsycastBase">
     <defName>VPE_Timequake</defName>
     <label>timequake</label>
-    <description>Find a discontinuity in the psychic field and compress it, releasing a massive temporal disturbance. Every creature in range but outside of the safe inner circle will experience rapid aging and structures will warp. Casting this takes 20 seconds of meditation, and afterwards, the caster will go into a five-day psychic coma. The disturbing timequake echoes will inflict pain on everyone for many kilometers around, causing diplomatic consequences with all factions.</description>
+    <description>Find a discontinuity in the psychic field and compress it, releasing a massive temporal disturbance. Every creature in range but outside of the safe inner circle will experience rapid aging and structures will warp. Casting this takes 20 seconds of meditation, and afterwards, the caster will go into a psychic coma. The disturbing timequake echoes will inflict pain on everyone for many kilometers around, causing diplomatic consequences with all factions.</description>
     <iconPath>Abilities/Chronopath/Timequake</iconPath>
     <abilityClass>VanillaPsycastsExpanded.Chronopath.Ability_TimeQuake</abilityClass>
     <castTime>1200</castTime>
@@ -329,7 +329,7 @@
         <hours>120</hours>
       </li>
       <li Class="VFECore.Abilities.AbilityExtension_ConfirmationMessage">
-        <message>If you use timequake, everyone in this region will feel the timequake echo, you will lose goodwill with every non-hostile faction.\n\nTimequake takes 20 seconds to cast, and cannot be interrupted. When complete, the caster will fall into a psychic coma for 5 days.\n\nEveryone except those in a small circle around the caster will be affected.\n\nDo you really want to cast timequake?</message>
+        <message>If you use timequake, everyone in this region will feel the timequake echo, you will lose goodwill with every non-hostile faction.\n\nTimequake takes 20 seconds to cast, and cannot be interrupted. When complete, the caster will fall into a psychic coma for up to 5 days.\n\nEveryone except those in a small circle around the caster will be affected.\n\nDo you really want to cast timequake?</message>
       </li>
       <li Class="VFECore.Abilities.AbilityExtension_FleckOnTarget">
         <fleckDef>PsychicApplyNeuroquake</fleckDef>

--- a/1.5/Defs/AbilityDefs/Conflagrator.xml
+++ b/1.5/Defs/AbilityDefs/Conflagrator.xml
@@ -254,7 +254,7 @@
   <VFECore.Abilities.AbilityDef ParentName="VPE_PsycastBase">
     <defName>VPE_FireBeam</defName>
     <label>fire beam</label>
-    <description>Attempts to recreate the power of a star inside a concentrated column of almost liquidized oxygen. The resulting emission of plasma is so powerful that only the most advanced weapons systems can hope to compare. The long, intense concentration ends with the caster falling into a 6-hour coma.</description>
+    <description>Attempts to recreate the power of a star inside a concentrated column of almost liquidized oxygen. The resulting emission of plasma is so powerful that only the most advanced weapons systems can hope to compare. The long, intense concentration ends with the caster falling into a coma.</description>
     <iconPath>Abilities/Conflagrator/FireBeam</iconPath>
     <abilityClass>VFECore.Abilities.Ability_OrbitalStrike</abilityClass>
     <castTime>300</castTime>

--- a/1.5/Defs/AbilityDefs/Empath.xml
+++ b/1.5/Defs/AbilityDefs/Empath.xml
@@ -312,7 +312,7 @@
   <VFECore.Abilities.AbilityDef ParentName="VPE_PsycastGoToTargetBase">
     <defName>VPE_ReunionFarskip</defName>
     <label>reunion farskip</label>
-    <description>After a short meditation period and followed by a 5-day coma, taps into a target’s bloodline to skip all living family members to their proximity, knocked out through psychic shock. However, it does nothing to change their relationships and is considered rude by all other factions.</description>
+    <description>After a short meditation period and followed by a coma, taps into a target’s bloodline to skip all living family members to their proximity, knocked out through psychic shock. However, it does nothing to change their relationships and is considered rude by all other factions.</description>
     <iconPath>Abilities/Empath/ReunionFarskip</iconPath>
     <abilityClass>VanillaPsycastsExpanded.Ability_ReunionFarskip</abilityClass>
     <castTime>720</castTime>

--- a/1.5/Defs/AbilityDefs/Frostshaper.xml
+++ b/1.5/Defs/AbilityDefs/Frostshaper.xml
@@ -299,7 +299,7 @@
   <VFECore.Abilities.AbilityDef ParentName="VPE_PsycastBase">
     <defName>VPE_Blizzard</defName>
     <label>blizzard</label>
-    <description>Using differential-pressure skipgates, water-linked skipgates and nodes of psychic entropy, creates a swirling blizzard away from the caster. Those exposed to the tempest experience reduced sight, moving and manipulation, as well as hypothermia buildup and cutting cold. Duration scales with the caster’s psychic sensitivity and puts them in a 5-day coma.</description>
+    <description>Using differential-pressure skipgates, water-linked skipgates and nodes of psychic entropy, creates a swirling blizzard away from the caster. Those exposed to the tempest experience reduced sight, moving and manipulation, as well as hypothermia buildup and cutting cold. Duration scales with the caster’s psychic sensitivity and puts them in a coma.</description>
     <iconPath>Abilities/Frostshaper/Blizzard</iconPath>
     <durationTime>1200</durationTime>
     <abilityClass>VFECore.Abilities.Ability_Blank</abilityClass>
@@ -327,6 +327,11 @@
       <li Class="VFECore.Abilities.AbilityExtension_Hediff">
         <hediff>VPE_BlizzardSource</hediff>
         <durationMultiplier>PsychicSensitivity</durationMultiplier>
+      </li>
+      <li Class="VanillaPsycastsExpanded.AbilityExtension_PsychicComa">
+        <hours>120</hours>
+        <!-- Special case for blizzard - coma added by hediff once it runs out. -->
+        <autoApply>false</autoApply>
       </li>
     </modExtensions>
   </VFECore.Abilities.AbilityDef>

--- a/1.5/Defs/AbilityDefs/Harmonist.xml
+++ b/1.5/Defs/AbilityDefs/Harmonist.xml
@@ -310,7 +310,7 @@
   <VFECore.Abilities.AbilityDef ParentName="VPE_PsycastBase">
     <defName>VPE_SkillRoll</defName>
     <label>skillroll</label>
-    <description>Initiates a shift in the target’s knowledge and accumulated skills, attempting to rebalance them somewhat chaotically with some beneficial guidance. The strain puts the caster in a coma for a day, but can be reduced with psychic sensitivity.</description>
+    <description>Initiates a shift in the target’s knowledge and accumulated skills, attempting to rebalance them somewhat chaotically with some beneficial guidance. The strain puts the caster in a coma.</description>
     <iconPath>Abilities/Harmonist/SkillRoll</iconPath>
     <abilityClass>VanillaPsycastsExpanded.Harmonist.Ability_Skillroll</abilityClass>
     <castTime>720</castTime>

--- a/1.5/Defs/AbilityDefs/Necropath.xml
+++ b/1.5/Defs/AbilityDefs/Necropath.xml
@@ -302,7 +302,7 @@
 	<VFECore.Abilities.AbilityDef ParentName="VPE_PsycastGoToTargetBase">
 		<defName>VPE_Resurrect</defName>
 		<label>resurrect</label>
-		<description>By sacrificing a natural finger, the caster is able to imitate the effects of resurrector mech serum on any non-dessicated corpse, the psychic energy repairing broken-down tissues and kickstarting the body back to life. The target will be incapacitated and their allegiances will remain the same. The less preserved the body is, the more likely the target is to suffer from negative side effects. The long, intense concentration ends with the caster falling into a 6-hour coma.</description>
+		<description>By sacrificing a natural finger, the caster is able to imitate the effects of resurrector mech serum on any non-dessicated corpse, the psychic energy repairing broken-down tissues and kickstarting the body back to life. The target will be incapacitated and their allegiances will remain the same. The less preserved the body is, the more likely the target is to suffer from negative side effects. The long, intense concentration ends with the caster falling into a coma.</description>
 		<iconPath>Abilities/Necropath/Resurrect</iconPath>
 		<abilityClass>VanillaPsycastsExpanded.Ability_Resurrect</abilityClass>
 		<castTime>600</castTime>

--- a/1.5/Defs/AbilityDefs/Wildspeaker.xml
+++ b/1.5/Defs/AbilityDefs/Wildspeaker.xml
@@ -290,7 +290,7 @@
   <VFECore.Abilities.AbilityDef ParentName="VPE_PsycastBase">
     <defName>VPE_EssenceTransfer</defName>
     <label>essence transfer</label>
-    <description>Infuses the life force of another nearby person into a colony animal, linking them and putting the caster in a 6 hour coma. Should the linked person die, the linked animal will go to their side and transfer their own harmonized life essence to them, dying upon completion. Should the linked animal die first, the effect is lost, and there can only be one link at a time.</description>
+    <description>Infuses the life force of another nearby person into a colony animal, linking them and putting the caster in a coma. Should the linked person die, the linked animal will go to their side and transfer their own harmonized life essence to them, dying upon completion. Should the linked animal die first, the effect is lost, and there can only be one link at a time.</description>
     <iconPath>Abilities/Wildspeaker/EssenceTransfer</iconPath>
     <abilityClass>VanillaPsycastsExpanded.Wildspeaker.Ability_EssenceTransfer</abilityClass>
     <targetCount>2</targetCount>

--- a/1.5/Source/VanillaPsycastsExpanded/Common/AbilityExtension_PsychicComa.cs
+++ b/1.5/Source/VanillaPsycastsExpanded/Common/AbilityExtension_PsychicComa.cs
@@ -13,17 +13,46 @@ public class AbilityExtension_PsychicComa : AbilityExtension_AbilityMod
     public HediffDef coma;
     public StatDef   multiplier;
     public int       ticks;
+    public bool      autoApply = true;
 
-    public override void Cast(GlobalTargetInfo[] targets, Ability ability)
+    public virtual int GetComaDuration(Ability ability)
     {
-        base.Cast(targets, ability);
         float duration = this.hours * GenDate.TicksPerHour + this.ticks;
         float mult     = ability.pawn.GetStatValue(this.multiplier ?? StatDefOf.PsychicSensitivity);
 
         duration *= Mathf.Approximately(mult, 0f) ? 10f : 1 / mult;
+        return Mathf.FloorToInt(duration);
+    }
 
-        Hediff hediff = HediffMaker.MakeHediff(this.coma ?? VPE_DefOf.PsychicComa, ability.pawn);
-        hediff.TryGetComp<HediffComp_Disappears>().ticksToDisappear = Mathf.FloorToInt(duration);
-        ability.pawn.health.AddHediff(hediff);
+    public virtual void ApplyComa(Ability ability)
+    {
+        int duration = GetComaDuration(ability);
+
+        if (duration > 0)
+        {
+            Hediff hediff = HediffMaker.MakeHediff(this.coma ?? VPE_DefOf.PsychicComa, ability.pawn);
+            hediff.TryGetComp<HediffComp_Disappears>().ticksToDisappear = duration;
+            ability.pawn.health.AddHediff(hediff);
+        }
+    }
+
+    public override void Cast(GlobalTargetInfo[] targets, Ability ability)
+    {
+        base.Cast(targets, ability);
+
+        if (autoApply)
+        {
+            ApplyComa(ability);
+        }
+    }
+
+    public override string GetDescription(Ability ability)
+    {
+        int duration = GetComaDuration(ability);
+
+        if (duration > 0)
+            return $"{"VPE.PsychicComaDuration".Translate()}: {duration.ToStringTicksToPeriod(false)}".Colorize(Color.red);
+
+        return string.Empty;
     }
 }

--- a/1.5/Source/VanillaPsycastsExpanded/Paths/Archon/Ability_PsychicComa.cs
+++ b/1.5/Source/VanillaPsycastsExpanded/Paths/Archon/Ability_PsychicComa.cs
@@ -12,9 +12,16 @@
         public override void Cast(params GlobalTargetInfo[] targets)
         {
             base.Cast(targets);
-            var coma = HediffMaker.MakeHediff(VPE_DefOf.PsychicComa, this.pawn);
-            coma.TryGetComp<HediffComp_Disappears>().ticksToDisappear = (int)((GenDate.TicksPerDay * 5) / this.pawn.GetStatValue(StatDefOf.PsychicSensitivity));
-            this.pawn.health.AddHediff(coma);
+
+            // If a psychic coma ability extension is present then let
+            // it handle this instead. It has more customization to it.
+            // This class is basically for abilities using it for compatibility reasons.
+            if (!def.HasModExtension<AbilityExtension_PsychicComa>())
+            {
+                var coma = HediffMaker.MakeHediff(VPE_DefOf.PsychicComa, this.pawn);
+                coma.TryGetComp<HediffComp_Disappears>().ticksToDisappear = (int)((GenDate.TicksPerDay * 5) / this.pawn.GetStatValue(StatDefOf.PsychicSensitivity));
+                this.pawn.health.AddHediff(coma);
+            }
         }
     }
 }

--- a/1.5/Source/VanillaPsycastsExpanded/Paths/Archotechist/AbilityExtension_Neuroquake.cs
+++ b/1.5/Source/VanillaPsycastsExpanded/Paths/Archotechist/AbilityExtension_Neuroquake.cs
@@ -106,9 +106,6 @@
 			base.Cast(targets, ability);
 			affectedFactions.Clear();
 			giveMentalStateTo.Clear();
-			var coma = HediffMaker.MakeHediff(VPE_DefOf.PsychicComa, ability.pawn);
-			coma.TryGetComp<HediffComp_Disappears>().ticksToDisappear = (int)((GenDate.TicksPerDay * 5) / ability.pawn.GetStatValue(StatDefOf.PsychicSensitivity));
-			ability.pawn.health.AddHediff(coma);
 		}
 
 		private void AffectGoodwill(Faction faction, bool gaveMentalBreak, Pawn p = null)

--- a/1.5/Source/VanillaPsycastsExpanded/Paths/FrostShaper/Hediff_BlizzardSource.cs
+++ b/1.5/Source/VanillaPsycastsExpanded/Paths/FrostShaper/Hediff_BlizzardSource.cs
@@ -23,9 +23,7 @@ public class Hediff_BlizzardSource : Hediff_Overlay
     {
         base.PostRemoved();
         pawn.Map.GetComponent<MapComponent_PsycastsManager>().blizzardSources.Remove(this);
-        var coma = HediffMaker.MakeHediff(VPE_DefOf.PsychicComa, pawn);
-        coma.TryGetComp<HediffComp_Disappears>().ticksToDisappear = (int)(GenDate.TicksPerDay * 5 / pawn.GetStatValue(StatDefOf.PsychicSensitivity));
-        pawn.health.AddHediff(coma);
+        ability?.def.GetModExtension<AbilityExtension_PsychicComa>()?.ApplyComa(ability);
     }
 
     public override void Tick()

--- a/Languages/English/Keyed/UI.xml
+++ b/Languages/English/Keyed/UI.xml
@@ -48,4 +48,5 @@ Capturing psycasters is a viable strategy and can be considered beneficial.</VPE
     <VPE.LockedTitle>Locked: Requires a Royal Title</VPE.LockedTitle>
     <VPE.LockedLocked>Locked: Cannot be unlocked with points</VPE.LockedLocked>
     <VPE.SuccessChance>Success chance</VPE.SuccessChance>
+    <VPE.PsychicComaDuration>Psychic coma for</VPE.PsychicComaDuration>
 </LanguageData>


### PR DESCRIPTION
- Several changes to `AbilityExtension_PsychicComa`:
  - `AbilityExtension_PsychicComa` will now include coma duration in the ability tooltip
    - Sadly, it was not possible to cleanly implement it for `Ability_PsychicComa`
  - Added `autoApply` field (true by default)
    - The hediff will be automatically applied after casting if it's true - if false the ability will need to manually handle applying the hediff
  - Added `GetComaDuration` method which will calculate the duration of the coma for the caster
    - The method is virtual, so it'll be easy to implement other duration formulas if needed
  - Added `ApplyComa` method which will apply the coma to the caster
    - Can be used for convenience to apply the coma from different places in code
    - The method is virtual, so it'll be easy to change its behaviour if needed
- `AbilityExtension_Neuroquake` no longer applies psychic coma
  - The Neuroquake ability handles psychic coma through `AbilityExtension_PsychicComa`
  - This means other it should be possible to implement Neuroquake that doesn't cause coma without custom code, if needed
- `Hediff_BlizzardSource` now applies the hediff using the abilities `AbilityExtension_PsychicComa`
  - If the ability does not include that specific defModExtension then the coma won't be applied
  - This specifically requires setting `autoApply` to false so the coma won't be applied until the blizzard runs out
  - This means other it should be possible to implement Blizzard that doesn't cause coma without custom code, if needed
- `Ability_PsychicComa` won't apply the psychic coma if there's `AbilityExtension_PsychicComa` present
  - Considering that this defModExtension has more customizability and features, there's no reason to use tha `Ability_PsychicComa` to achieve this
  - Since it's not easily possible to change the `abilityClass` for an ability possessed by a pawn in-game (as far as I understand), this exists as a compatibility layer for abilities that want to modify their psychic coma without having to change the `abilityClass`
- Removed all mentions of the psychic coma duration from all ability descriptions
- Warning messages when casting neuroquake and timequake now mention that the coma lasts up to 5 days