### PR TITLE
Most likely fix issues with wealth meditation

### DIFF
--- a/1.5/Source/VanillaPsycastsExpanded/Meditation/StatPart_NearbyWealth.cs
+++ b/1.5/Source/VanillaPsycastsExpanded/Meditation/StatPart_NearbyWealth.cs
@@ -1,4 +1,6 @@
-﻿namespace VanillaPsycastsExpanded;
+﻿using UnityEngine;
+
+namespace VanillaPsycastsExpanded;
 
 using System.Linq;
 using RimWorld;
@@ -10,8 +12,12 @@ public class StatPart_NearbyWealth : StatPart_Focus
     {
         if (!this.ApplyOn(req) || req.Thing.Map == null) return;
 
-        float total  = req.Thing.Map.wealthWatcher.WealthTotal;
-        float nearby = GenRadialCached.RadialDistinctThingsAround(req.Thing.Position, req.Thing.Map, 6f, true).Sum(t => t.MarketValue * t.stackCount);
+        // Use the map's wealth, with a minimum of 1000.
+        // Negative values and zero would cause bugs.
+        float total  = Mathf.Max(req.Thing.Map.wealthWatcher.WealthTotal, 1000f);
+        // Use the wealth around location, but no more than total map wealth
+        float nearby = Mathf.Min(GenRadialCached.RadialDistinctThingsAround(req.Thing.Position, req.Thing.Map, 6f, true).Sum(t => t.MarketValue * t.stackCount), total);
+
         val += nearby / total;
     }
 


### PR DESCRIPTION
The main issue seems to happen when the total map wealth is 0. Since we divide the nearby wealth by total (in the case of our issue - 0) it would result in positive/negative infinity or NaN (depending on if the total was positive/negative/also zero).

Changes:
- The total map value will have a minimum value of 1000 (picked arbitrarily)
  - This will ensure that the value cannot be 0 (preventing bugs)
- The nearby wealth value will be capped at the total map wealth value
  - This will basically cap the bonus from wealth meditation at +100%