### PR TITLE
Fix the ability to level the psylink over maximum

### DIFF
--- a/1.5/Source/VanillaPsycastsExpanded/Hediff_PsycastAbilities.cs
+++ b/1.5/Source/VanillaPsycastsExpanded/Hediff_PsycastAbilities.cs
@@ -160,7 +160,7 @@ public class Hediff_PsycastAbilities : Hediff_Abilities
         if (level >= PsycastsMod.Settings.maxLevel) return;
         experience += experienceGain;
         var newLevelWasGainedAlready = false;
-        while (experience >= ExperienceRequiredForLevel(level + 1))
+        while (level < PsycastsMod.Settings.maxLevel && experience >= ExperienceRequiredForLevel(level + 1))
         {
             ChangeLevel(1, sendLetter && !newLevelWasGainedAlready);
             newLevelWasGainedAlready = true;


### PR DESCRIPTION
Currently, if a pawn suddenly gains a significant amount of XP in a single instant then they're able to go over the maximum level specified in settings.

This happens due to the check for max level happens before the pawn gains XP - it prevents them from gaining more at max level. However, after passing that check, there is no such check when gaining levels, meaning that if a pawn were to gain enough XP to level up multiple times they may go over the maximum.

I've added a second check in the code for gaining levels to make sure that a pawn is still under the max level after each level up.

This is mostly a precaution, as it should not really be possible to gain multiple levels like this. However, it has happened with a bug related to wealth meditation, so I've decided to take it safe in case of similar bugs.