### PR TITLE
ExperienceRequiredForLevel optimization

### DIFF
--- a/1.6/Source/VanillaPsycastsExpanded/Hediff_PsycastAbilities.cs
+++ b/1.6/Source/VanillaPsycastsExpanded/Hediff_PsycastAbilities.cs
@@ -247,9 +247,9 @@ public class Hediff_PsycastAbilities : Hediff_Abilities
         level switch
         {
             <= 1 => 100,
-            <= 20 => Mathf.RoundToInt(ExperienceRequiredForLevel(level - 1) * 1.15f),
-            <= 30 => Mathf.RoundToInt(ExperienceRequiredForLevel(level - 1) * 1.10f),
-            _ => Mathf.RoundToInt(ExperienceRequiredForLevel(level - 1) * 1.05f)
+            <= 20 => Mathf.RoundToInt(100 * Mathf.Pow(1.15f, level - 1)),
+            <= 30 => Mathf.RoundToInt(1636 * Mathf.Pow(1.10f, level - 20)),
+            _ => Mathf.RoundToInt(4243 * Mathf.Pow(1.05f, level - 30))
         };
 
     public override void GiveRandomAbilityAtLevel(int? forLevel = null) { }


### PR DESCRIPTION
I notice a visible performance hit when my pawns were meditating and decided to look into it a bit.
The way I understand it every tick a pawn is meditating it calls GainExperience -> ExperienceRequiredForLevel, which recursively calls itself 'level' times to produce the answer. Ideally that result should be cached so the calculation only needs to be made once, but I don't know enough about c# to do that, so instead I reduced it to two math operations and removed the recursion.

This is my first time having a deeper look at Rimworld c# modding, so I couldn't test this and don't know if it will actually have a positive impact, so I present it for your consideration in the hope it's helpful.

Love the mod and all of your hard work