### PR TITLE
Fix Nightstalker Obscure ability.

### DIFF
--- a/1.6/Defs/HediffDefs/Hediffs.xml
+++ b/1.6/Defs/HediffDefs/Hediffs.xml
@@ -650,8 +650,8 @@
 			<li>
 				<compClass>VanillaPsycastsExpanded.Nightstalker.HediffComp_DissapearsOnAttack</compClass>
 			</li>
-			<li>
-				<compClass>HediffComp_Invisibility</compClass>
+			<li Class="HediffCompProperties_Invisibility">
+			    <visibleToPlayer>true</visibleToPlayer>
 			</li>
 		</comps>
 	</HediffDef>


### PR DESCRIPTION
Hi, I encountered an error when using the obscure ability for Nightstalker.
I tested this fix on a clean save with only this mod installed, and it appears to fix it.

based on this: https://github.com/Vanilla-Expanded/VanillaExpandedFramework/blob/f975b48f59993d9fd63be9f6f81ab16a8cb47f74/1.6/Defs/HediffDefs/Hediffs_Global_Misc.xml#L361