### PR TITLE
Technomancer Mend can now target self.

### DIFF
--- a/1.4/Defs/AbilityDefs/Technomancer.xml
+++ b/1.4/Defs/AbilityDefs/Technomancer.xml
@@ -54,6 +54,7 @@
       <canTargetLocations>false</canTargetLocations>
       <canTargetBuildings>true</canTargetBuildings>
       <canTargetPawns>true</canTargetPawns>
+      <canTargetSelf>true</canTargetSelf>
       <canTargetMechs>true</canTargetMechs>
       <canTargetAnimals>false</canTargetAnimals>
       <onlyRepairableMechs>true</onlyRepairableMechs>

--- a/1.5/Defs/AbilityDefs/Technomancer.xml
+++ b/1.5/Defs/AbilityDefs/Technomancer.xml
@@ -54,6 +54,7 @@
       <canTargetLocations>false</canTargetLocations>
       <canTargetBuildings>true</canTargetBuildings>
       <canTargetPawns>true</canTargetPawns>
+      <canTargetSelf>true</canTargetSelf>
       <canTargetMechs>true</canTargetMechs>
       <canTargetAnimals>false</canTargetAnimals>
       <onlyRepairableMechs>true</onlyRepairableMechs>

--- a/1.6/Defs/AbilityDefs/Technomancer.xml
+++ b/1.6/Defs/AbilityDefs/Technomancer.xml
@@ -54,6 +54,7 @@
       <canTargetLocations>false</canTargetLocations>
       <canTargetBuildings>true</canTargetBuildings>
       <canTargetPawns>true</canTargetPawns>
+      <canTargetSelf>true</canTargetSelf>
       <canTargetMechs>true</canTargetMechs>
       <canTargetAnimals>false</canTargetAnimals>
       <onlyRepairableMechs>true</onlyRepairableMechs>


### PR DESCRIPTION
The Mend psycast can already target other pawns, now a psycaster can repair their own gear without removing it.