### PR TITLE
removing goodwill loss from word of productivity

### DIFF
--- a/1.4/Defs/AbilityDefs/Archon.xml
+++ b/1.4/Defs/AbilityDefs/Archon.xml
@@ -40,7 +40,6 @@
 		<iconPath>Abilities/Archon/WordofProductivity</iconPath>
 		<castTime>120</castTime>
 		<durationTime>300000</durationTime>
-		<goodwillImpact>-10</goodwillImpact>
 		<showUndrafted>true</showUndrafted>
 		<chance>0</chance>
 		<modExtensions>

--- a/1.5/Defs/AbilityDefs/Archon.xml
+++ b/1.5/Defs/AbilityDefs/Archon.xml
@@ -40,7 +40,6 @@
 		<iconPath>Abilities/Archon/WordofProductivity</iconPath>
 		<castTime>120</castTime>
 		<durationTime>300000</durationTime>
-		<goodwillImpact>-10</goodwillImpact>
 		<showUndrafted>true</showUndrafted>
 		<chance>0</chance>
 		<modExtensions>

--- a/1.6/Defs/AbilityDefs/Archon.xml
+++ b/1.6/Defs/AbilityDefs/Archon.xml
@@ -40,7 +40,6 @@
 		<iconPath>Abilities/Archon/WordofProductivity</iconPath>
 		<castTime>120</castTime>
 		<durationTime>300000</durationTime>
-		<goodwillImpact>-10</goodwillImpact>
 		<showUndrafted>true</showUndrafted>
 		<chance>0</chance>
 		<modExtensions>


### PR DESCRIPTION
This change removes the goodwill impact from word of productivity. I am of the opinion that this does not make logical sense. If the devs disagree, i wont complain, but i figured id pop a little change in. closes issue #35 